### PR TITLE
Django 1.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 script: "python ./runtests.py"
 before_install:
-    - sudo apt-get install swig
+    - sudo apt-get install libssl-dev
 install:
-    - "./m2crypto_ubuntu"
     - "pip install Django==$DJANGO"
     - "python setup.py install"
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ env:
     - DJANGO=1.8
 python:
     - "2.7"
-    - "3.2.3"
+    - "3.4"
 
 matrix:
     exclude:
-        - python: "3.2.3"
+        - python: "3.4"
           env: DJANGO=1.3.7
-        - python: "3.2.3"
+        - python: "3.4"
           env: DJANGO=1.4.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,11 @@ env:
     - DJANGO=1.6.2
     - DJANGO=1.8
 python:
-    - "2.6"
     - "2.7"
     - "3.2.3"
 
 matrix:
     exclude:
-        - python: "2.6"
-          env: DJANGO=1.8
         - python: "3.2.3"
           env: DJANGO=1.3.7
         - python: "3.2.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,13 @@ env:
 python:
     - "2.6"
     - "2.7"
+    - "3.2.3"
 
 matrix:
     exclude:
         - python: "2.6"
           env: DJANGO=1.8
+        - python: "3.2.3"
+          env: DJANGO=1.3.7
+        - python: "3.2.3"
+          env: DJANGO=1.4.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ env:
     - DJANGO=1.4.5
     - DJANGO=1.5.1
     - DJANGO=1.6.2
+    - DJANGO=1.8
 python:
     - "2.6"
     - "2.7"
+
+matrix:
+    exclude:
+        - python: "2.6"
+          env: DJANGO=1.8

--- a/runtests.py
+++ b/runtests.py
@@ -3,6 +3,7 @@ import sys
 
 from os.path import dirname, abspath
 
+import django
 from django.conf import settings
 
 if not settings.configured:
@@ -17,12 +18,16 @@ if not settings.configured:
         WEBTOPAY_PASSWORD='1c4196d0ff7fe4e94bdca98fb251bc25'
     )
 
-from django.test.simple import DjangoTestSuiteRunner
+if django.VERSION >= (1, 8):
+    from django.test.runner import DiscoverRunner as DjangoTestRunner
+    django.setup()
+else:
+    from django.test.simple import DjangoTestSuiteRunner as DjangoTestRunner
 
 def runtests(*args):
     parent = dirname(abspath(__file__))
     sys.path.insert(0, parent)
-    testrunner = DjangoTestSuiteRunner()
+    testrunner = DjangoTestRunner()
     if not args:
         args = None
     failures = testrunner.run_tests(args)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author='Motiejus Jakštys',
     author_email='desired.mta@gmail.com',
     url='https://github.com/Motiejus/django-webtopay',
-    install_requires=['Django>=1.3', 'M2crypto'],
+    install_requires=['Django>=1.3', 'pyopenssl'],
     description = 'A pluggable Django application for integrating WebToPay Payments',
     packages=find_packages(),
     classifiers=[

--- a/webtopay/forms.py
+++ b/webtopay/forms.py
@@ -1,5 +1,8 @@
 # -*- coding: UTF-8 -*-
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError
+    from django.utils.datastructures import SortedDict as OrderedDict
 import six
 import base64
 import logging

--- a/webtopay/forms.py
+++ b/webtopay/forms.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 try:
     from collections import OrderedDict
-except ImportError
+except ImportError:
     from django.utils.datastructures import SortedDict as OrderedDict
 import six
 import base64

--- a/webtopay/forms.py
+++ b/webtopay/forms.py
@@ -24,6 +24,7 @@ log = logging.getLogger(__name__)
 class WebToPayResponseForm(forms.ModelForm):
     class Meta:
         model = WebToPayResponse
+        exclude = []
 
     def __init__(self, data_orig, **kargs):
         # Remove prefix from parameters
@@ -156,7 +157,7 @@ class WebToPaymentForm(forms.Form):
 
         Apmokėjimas už prekes pagal užsakymą [order_nr] svetainėje [site_name].
     """
-    
+
     p_firstname = forms.CharField(max_length=255, required=False,
             widget=ValueHiddenInput(),
             help_text="Pirkėjo vardas. Pageidautina daugumoje mokėjimo būdų. "\

--- a/webtopay/forms.py
+++ b/webtopay/forms.py
@@ -1,8 +1,6 @@
 # -*- coding: UTF-8 -*-
-try:
-    from collections import OrderedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict as OrderedDict
+
+from collections import OrderedDict
 import six
 import base64
 import logging
@@ -304,4 +302,8 @@ class WebToPaymentForm(forms.Form):
 class Helpers:
     @staticmethod
     def generate_ss1(values, sep):
-        return md5(sep.join(map(six.u, values)).encode('utf8')).hexdigest()
+        if six.PY3:
+            values = map(str, values)
+        else:
+            values = map(unicode, values)
+        return md5(sep.join(values).encode('utf8')).hexdigest()

--- a/webtopay/models.py
+++ b/webtopay/models.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
 
+import django
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from webtopay.signals import payment_was_successful, payment_was_flagged
+
+if django.VERSION >= (1, 4):
+    ipfield = models.GenericIPAddressField
+else:
+    ipfield = models.IPAddressField
 
 class WebToPayResponse(models.Model):
     # Non-webtopay params
@@ -13,7 +19,7 @@ class WebToPayResponse(models.Model):
         return "%s %.2f" % (self.currency, amount)
 
     query = models.TextField(blank=True)
-    ipaddress = models.IPAddressField(blank=True)
+    ipaddress = ipfield(blank=True, null=True)
     flag = models.BooleanField(blank=True, default=False)
     flag_info = models.TextField(blank=True)
 
@@ -65,7 +71,7 @@ class WebToPayResponse(models.Model):
     surename = models.CharField(max_length=255, blank=True,
             help_text="Mokėtojo pavardė, gauta iš mokėjimo sistemos. "+\
                     "Siunčiamas tik jeigu mokėjimo sistema tokį suteikia")
-    status = models.IntegerField(max_length=255, help_text="Mokėjimo būklė: "+\
+    status = models.IntegerField(help_text="Mokėjimo būklė: "+\
                     "0 - apmokėjimas neįvyko, "+\
                     "1 - apmokėta sėkmingai, "+\
                     "2 - mokėjimo nurodymas priimtas, bet dar neįvykdytas",

--- a/webtopay/tests.py
+++ b/webtopay/tests.py
@@ -1,13 +1,9 @@
 # -*- coding: UTF-8 -*-
 
-from urllib import unquote_plus, urlencode
-import base64
-import pdb
 import logging
 
 from django.test import TestCase
 from django.test.client import Client
-from django.utils.datastructures import SortedDict
 
 from webtopay.forms import WebToPayResponseForm
 from webtopay.signals import payment_was_successful, payment_was_flagged
@@ -89,4 +85,4 @@ class TestSignals(TestCase):
         logger.setLevel(100)
         resp = self.client.get("?" + query)
         logger.setLevel(old_level)
-        self.assertEqual("OK", resp.content)
+        self.assertEqual(str("OK"), str(resp.content.decode('utf-8')))

--- a/webtopay/views.py
+++ b/webtopay/views.py
@@ -40,7 +40,7 @@ def makro(request):
     # get instance of WebToPayResponse
     try:
         resp_obj = form.save(commit=False)
-    except Exception, e:
+    except Exception as e:
         return _respond_error(request, "Exception while processing (%s)" % e)
 
     return _respond(resp_obj, request)


### PR DESCRIPTION
- `ModelForm` requires `exclude` parameter.
- `IPAddressField` was added next to `GenericIPAddressField` since django 1.4  and removed in 1.8 (https://code.djangoproject.com/ticket/20439)
- django raises warning when `max_length` keyword argument is passed to `IntegerField` 
- `django.test.runner.DiscoverRunner` is removed. Instead use `django.test.runner.DiscoverRunner`. And need to call `django.setup()` before starting test runner.
